### PR TITLE
SPI Updates

### DIFF
--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -112,11 +112,6 @@ All text above, and the splash screen must be included in any redistribution
 class Adafruit_SSD1306 : public Adafruit_GFX {
  public:
 
-  enum SpiPeripheral {
-    PERIPH_SPI,
-    PERIPH_SPI1,
-  };
-
   Adafruit_SSD1306(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST, int8_t CS);
   Adafruit_SSD1306(int8_t DC, int8_t RST, int8_t CS, bool USE_SPI1 = false);
   Adafruit_SSD1306(int8_t RST);

--- a/Adafruit_SSD1306.h
+++ b/Adafruit_SSD1306.h
@@ -111,8 +111,14 @@ All text above, and the splash screen must be included in any redistribution
 
 class Adafruit_SSD1306 : public Adafruit_GFX {
  public:
+
+  enum SpiPeripheral {
+    PERIPH_SPI,
+    PERIPH_SPI1,
+  };
+
   Adafruit_SSD1306(int8_t SID, int8_t SCLK, int8_t DC, int8_t RST, int8_t CS);
-  Adafruit_SSD1306(int8_t DC, int8_t RST, int8_t CS);
+  Adafruit_SSD1306(int8_t DC, int8_t RST, int8_t CS, bool USE_SPI1 = false);
   Adafruit_SSD1306(int8_t RST);
 
   void begin(uint8_t switchvcc = SSD1306_SWITCHCAPVCC, uint8_t i2caddr = SSD1306_I2C_ADDRESS);
@@ -139,6 +145,7 @@ class Adafruit_SSD1306 : public Adafruit_GFX {
 
  private:
   int8_t _i2caddr, _vccstate, sid, sclk, dc, rst, cs;
+  SPIClass * spiClass;
   void fastSPIwrite(uint8_t c);
 
   boolean hwSPI;


### PR DESCRIPTION
- Updated Adafruit_SSD1306 to optionally use SPI1.
- Pass chip select pin to spi::begin so that the driver
  no longer sets the pin mode for the default pins which may not
  be used.